### PR TITLE
Update Newtonsoft.JSON version, add nuspec file, bump version to 0.0.4-beta

### DIFF
--- a/DataDogCSharp/DataDogCSharp/DataDogCSharp.csproj
+++ b/DataDogCSharp/DataDogCSharp/DataDogCSharp.csproj
@@ -52,6 +52,7 @@
     <Compile Include="Serializers\DataDogPayloadSerializer.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="DataDogCSharp.nuspec" />
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/DataDogCSharp/DataDogCSharp/DataDogCSharp.csproj
+++ b/DataDogCSharp/DataDogCSharp/DataDogCSharp.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>DataDogCSharp</RootNamespace>
     <AssemblyName>DataDogCSharp</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/DataDogCSharp/DataDogCSharp/DataDogCSharp.csproj
+++ b/DataDogCSharp/DataDogCSharp/DataDogCSharp.csproj
@@ -31,9 +31,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/DataDogCSharp/DataDogCSharp/DataDogCSharp.nuspec
+++ b/DataDogCSharp/DataDogCSharp/DataDogCSharp.nuspec
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata>
+    <id>DataDogCSharp</id>
+    <version>$version$</version>
+    <authors>Jared Lutteke</authors>
+    <owners>SkyKick</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <licenseUrl>https://github.com/SkyKick/datadogcsharp/blob/feature/implement-client/LICENSE.md/</licenseUrl>
+    <projectUrl>https://github.com/SkyKick/datadogcsharp/tree/feature/implement-client/</projectUrl>
+    <iconUrl>https://www.skykick.com/svg/logo.svg</iconUrl>
+    <description>C# Library for interacting with DataDog's API</description>
+    <releaseNotes>Initial implementation.</releaseNotes>
+    <copyright>Copyright 2017</copyright>
+    <dependencies>
+      <dependency id="Newtonsoft.Json" version="10.0.2" />
+    </dependencies>
+  </metadata>
+</package>

--- a/DataDogCSharp/DataDogCSharp/Properties/AssemblyInfo.cs
+++ b/DataDogCSharp/DataDogCSharp/Properties/AssemblyInfo.cs
@@ -32,6 +32,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
-[assembly: AssemblyInformationalVersion("0.0.2-beta")]
+[assembly: AssemblyVersion("0.0.4.0")]
+[assembly: AssemblyFileVersion("0.0.4.0")]
+[assembly: AssemblyInformationalVersion("0.0.4-beta")]

--- a/DataDogCSharp/DataDogCSharp/packages.config
+++ b/DataDogCSharp/DataDogCSharp/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
Downgrading the Newtonsoft.Json version as some Microsoft libraries are not yet on the 10.x and have hard requirements for 9.x versions.

There is also a nuspec file now!